### PR TITLE
Fixed time dimension in resample_ann()

### DIFF
--- a/notebooks/Global Flux Table.ipynb
+++ b/notebooks/Global Flux Table.ipynb
@@ -36,9 +36,9 @@
       "CPU cores   : 72\n",
       "Architecture: 64bit\n",
       "\n",
-      "Hostname: casper-login2\n",
+      "Hostname: crhtc45\n",
       "\n",
-      "Git hash: 9ea3ad60e83b9a610032d9a3d502b83a1168dc24\n",
+      "Git hash: 4765c24f424e1f72cd7c482fcb36f5a554a0ad79\n",
       "\n",
       "pandas: 1.2.4\n",
       "\n"
@@ -76,6 +76,7 @@
     "vars = global_vars['vars']\n",
     "experiments = global_vars['experiments']\n",
     "experiment_longnames = global_vars['experiment_longnames']\n",
+    "experiment_len = global_vars['experiment_len']\n",
     "experiment_dict = global_vars['experiment_dict']\n",
     "time_slices = global_vars['time_slices']"
    ]
@@ -98,8 +99,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.43 s, sys: 101 ms, total: 1.53 s\n",
-      "Wall time: 1.61 s\n"
+      "CPU times: user 1.24 s, sys: 74.1 ms, total: 1.31 s\n",
+      "Wall time: 1.33 s\n"
      ]
     }
    ],
@@ -214,7 +215,7 @@
     }
    ],
    "source": [
-    "diagnostic_values = aau.compute_diagnostic_values(experiments, table_specs, ann_avg, time_slices, cesm_units, final_units, verbose=False)"
+    "diagnostic_values = aau.compute_diagnostic_values(experiments, table_specs, ann_avg, time_slices, cesm_units, final_units, experiment_len, verbose=False)"
    ]
   },
   {
@@ -738,7 +739,7 @@
        "      <td>-</td>\n",
        "      <td>-</td>\n",
        "      <td>77.6</td>\n",
-       "      <td>78.2</td>\n",
+       "      <td>78.3</td>\n",
        "      <td>69.8</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -774,7 +775,7 @@
        "      <td>193.7</td>\n",
        "      <td>187.5</td>\n",
        "      <td>184.8</td>\n",
-       "      <td>191.4</td>\n",
+       "      <td>191.6</td>\n",
        "      <td>255.8</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -819,7 +820,7 @@
        "      <td>5.2</td>\n",
        "      <td>-13.8</td>\n",
        "      <td>-14.1</td>\n",
-       "      <td>10.6</td>\n",
+       "      <td>10.3</td>\n",
        "      <td>-0.8</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -935,16 +936,16 @@
        "Net primary production, full depth (PgC/yr)              48.8   \n",
        "Sinking POC at 100 m (PgC/yr)                            7.05   \n",
        "Sinking CaCO$_3$ at 100 m (PgC/yr)                      0.767   \n",
-       "Sinking SiO$_2$ at 100 m (Tmol/yr)                       78.2   \n",
+       "Sinking SiO$_2$ at 100 m (Tmol/yr)                       78.3   \n",
        "Rain ratio (CaCO$_3$/POC) at 100 m                      0.109   \n",
        "Nitrogen fixation (TgN/yr)                              243.1   \n",
        "Nitrogen deposition (TgN/yr)                             37.2   \n",
-       "Water Column Denitrification (TgN/yr)                   191.4   \n",
+       "Water Column Denitrification (TgN/yr)                   191.6   \n",
        "Sediment Denitrification (TgN/yr)                          71   \n",
        "Nitrogen Burial to Sediment (TgN/yr)                       27   \n",
        "Nitrogen surface emissions (TgN/yr)                         5   \n",
        "Nitrogen River Flux (TgN/yr)                               25   \n",
-       "N cycle imbalance (TgN/yr)                               10.6   \n",
+       "N cycle imbalance (TgN/yr)                               10.3   \n",
        "Air-sea CO$_2$ flux (PgC/yr)                             2.04   \n",
        "Diatom primary production, top 100m (\\%)                   37   \n",
        "Diatom primary production, full depth (\\%)                 37   \n",
@@ -1026,16 +1027,16 @@
       "Net primary production, full depth (PgC/yr) &                 55.9* &               56.1* &                 54.0* &                  48.2 &              48.8 &                   49.8 \\\\\n",
       "              Sinking POC at 100 m (PgC/yr) &                  8.07 &                7.98 &                  7.20 &                  6.98 &              7.05 &                   6.69 \\\\\n",
       "         Sinking CaCO$_3$ at 100 m (PgC/yr) &                 0.757 &               0.748 &                 0.723 &                 0.767 &             0.767 &                  0.808 \\\\\n",
-      "         Sinking SiO$_2$ at 100 m (Tmol/yr) &                     - &                   - &                     - &                  77.6 &              78.2 &                   69.8 \\\\\n",
+      "         Sinking SiO$_2$ at 100 m (Tmol/yr) &                     - &                   - &                     - &                  77.6 &              78.3 &                   69.8 \\\\\n",
       "         Rain ratio (CaCO$_3$/POC) at 100 m &                 0.094 &               0.094 &                 0.100 &                 0.110 &             0.109 &                  0.121 \\\\\n",
       "                 Nitrogen fixation (TgN/yr) &                 175.3 &               169.4 &                 143.7 &                 240.6 &             243.1 &                  285.0 \\\\\n",
       "               Nitrogen deposition (TgN/yr) &                   6.6 &                29.6 &                  30.0 &                  13.3 &              37.2 &                   38.3 \\\\\n",
-      "      Water Column Denitrification (TgN/yr) &                 190.0 &               193.7 &                 187.5 &                 184.8 &             191.4 &                  255.8 \\\\\n",
+      "      Water Column Denitrification (TgN/yr) &                 190.0 &               193.7 &                 187.5 &                 184.8 &             191.6 &                  255.8 \\\\\n",
       "          Sediment Denitrification (TgN/yr) &                     - &                   - &                     - &                    67 &                71 &                     68 \\\\\n",
       "       Nitrogen Burial to Sediment (TgN/yr) &                     - &                   - &                     - &                    24 &                27 &                     22 \\\\\n",
       "        Nitrogen surface emissions (TgN/yr) &                     - &                   - &                     - &                     6 &                 5 &                      3 \\\\\n",
       "               Nitrogen River Flux (TgN/yr) &                     - &                   - &                     - &                    13 &                25 &                     25 \\\\\n",
-      "                 N cycle imbalance (TgN/yr) &                  -8.0 &                 5.2 &                 -13.8 &                 -14.1 &              10.6 &                   -0.8 \\\\\n",
+      "                 N cycle imbalance (TgN/yr) &                  -8.0 &                 5.2 &                 -13.8 &                 -14.1 &              10.3 &                   -0.8 \\\\\n",
       "               Air-sea CO$_2$ flux (PgC/yr) &                 -0.02 &                2.03 &                  4.71 &                 -0.04 &              2.04 &                   5.33 \\\\\n",
       "   Diatom primary production, top 100m (\\%) &                    34 &                  34 &                    32 &                    35 &                37 &                     31 \\\\\n",
       " Diatom primary production, full depth (\\%) &                   35* &                 35* &                   32* &                    36 &                37 &                     31 \\\\\n",

--- a/notebooks/Global Flux Table.ipynb
+++ b/notebooks/Global Flux Table.ipynb
@@ -38,7 +38,7 @@
       "\n",
       "Hostname: crhtc45\n",
       "\n",
-      "Git hash: 4765c24f424e1f72cd7c482fcb36f5a554a0ad79\n",
+      "Git hash: 4b226d26262ccbcfa3de24ba08a1145e9901a5fa\n",
       "\n",
       "pandas: 1.2.4\n",
       "\n"
@@ -76,7 +76,7 @@
     "vars = global_vars['vars']\n",
     "experiments = global_vars['experiments']\n",
     "experiment_longnames = global_vars['experiment_longnames']\n",
-    "experiment_len = global_vars['experiment_len']\n",
+    "experiment_span = global_vars['experiment_span']\n",
     "experiment_dict = global_vars['experiment_dict']\n",
     "time_slices = global_vars['time_slices']"
    ]
@@ -99,8 +99,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.24 s, sys: 74.1 ms, total: 1.31 s\n",
-      "Wall time: 1.33 s\n"
+      "CPU times: user 1.27 s, sys: 93.9 ms, total: 1.36 s\n",
+      "Wall time: 1.41 s\n"
      ]
     }
    ],
@@ -215,7 +215,14 @@
     }
    ],
    "source": [
-    "diagnostic_values = aau.compute_diagnostic_values(experiments, table_specs, ann_avg, time_slices, cesm_units, final_units, experiment_len, verbose=False)"
+    "diagnostic_values = aau.compute_diagnostic_values(experiments,\n",
+    "                                                  table_specs,\n",
+    "                                                  ann_avg,\n",
+    "                                                  time_slices,\n",
+    "                                                  cesm_units,\n",
+    "                                                  final_units,\n",
+    "                                                  experiment_span,\n",
+    "                                                  verbose=False)"
    ]
   },
   {
@@ -740,7 +747,7 @@
        "      <td>-</td>\n",
        "      <td>77.6</td>\n",
        "      <td>78.3</td>\n",
-       "      <td>69.8</td>\n",
+       "      <td>69.9</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Rain ratio (CaCO$_3$/POC) at 100 m</th>\n",
@@ -955,7 +962,7 @@
        "Net primary production, full depth (PgC/yr)                   49.8  \n",
        "Sinking POC at 100 m (PgC/yr)                                 6.69  \n",
        "Sinking CaCO$_3$ at 100 m (PgC/yr)                           0.808  \n",
-       "Sinking SiO$_2$ at 100 m (Tmol/yr)                            69.8  \n",
+       "Sinking SiO$_2$ at 100 m (Tmol/yr)                            69.9  \n",
        "Rain ratio (CaCO$_3$/POC) at 100 m                           0.121  \n",
        "Nitrogen fixation (TgN/yr)                                   285.0  \n",
        "Nitrogen deposition (TgN/yr)                                  38.3  \n",
@@ -1027,7 +1034,7 @@
       "Net primary production, full depth (PgC/yr) &                 55.9* &               56.1* &                 54.0* &                  48.2 &              48.8 &                   49.8 \\\\\n",
       "              Sinking POC at 100 m (PgC/yr) &                  8.07 &                7.98 &                  7.20 &                  6.98 &              7.05 &                   6.69 \\\\\n",
       "         Sinking CaCO$_3$ at 100 m (PgC/yr) &                 0.757 &               0.748 &                 0.723 &                 0.767 &             0.767 &                  0.808 \\\\\n",
-      "         Sinking SiO$_2$ at 100 m (Tmol/yr) &                     - &                   - &                     - &                  77.6 &              78.3 &                   69.8 \\\\\n",
+      "         Sinking SiO$_2$ at 100 m (Tmol/yr) &                     - &                   - &                     - &                  77.6 &              78.3 &                   69.9 \\\\\n",
       "         Rain ratio (CaCO$_3$/POC) at 100 m &                 0.094 &               0.094 &                 0.100 &                 0.110 &             0.109 &                  0.121 \\\\\n",
       "                 Nitrogen fixation (TgN/yr) &                 175.3 &               169.4 &                 143.7 &                 240.6 &             243.1 &                  285.0 \\\\\n",
       "               Nitrogen deposition (TgN/yr) &                   6.6 &                29.6 &                  30.0 &                  13.3 &              37.2 &                   38.3 \\\\\n",

--- a/notebooks/Make Timeseries.ipynb
+++ b/notebooks/Make Timeseries.ipynb
@@ -39,17 +39,17 @@
       "CPU cores   : 72\n",
       "Architecture: 64bit\n",
       "\n",
-      "Hostname: crhtc47\n",
+      "Hostname: crhtc45\n",
       "\n",
-      "Git hash: 9ea3ad60e83b9a610032d9a3d502b83a1168dc24\n",
+      "Git hash: 4765c24f424e1f72cd7c482fcb36f5a554a0ad79\n",
       "\n",
-      "intake       : 0.6.2\n",
-      "xarray       : 0.18.0\n",
-      "esmlab       : 2019.4.27.post56\n",
-      "numpy        : 1.20.2\n",
-      "ncar_jobqueue: 2021.4.14\n",
       "xpersist     : 2020.4.30.post8\n",
+      "esmlab       : 2019.4.27.post56\n",
       "intake_esm   : 2021.1.15.post12\n",
+      "ncar_jobqueue: 2021.4.14\n",
+      "xarray       : 0.18.0\n",
+      "numpy        : 1.20.2\n",
+      "intake       : 0.6.2\n",
       "\n"
      ]
     }
@@ -104,7 +104,7 @@
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3 style=\"text-align: left;\">Client</h3>\n",
        "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Scheduler: </b>tcp://10.12.206.48:42526</li>\n",
+       "  <li><b>Scheduler: </b>tcp://10.12.206.46:44096</li>\n",
        "  <li><b>Dashboard: </b><a href='https://jupyterhub.hpc.ucar.edu/stable/user/mlevy/proxy/8787/status' target='_blank'>https://jupyterhub.hpc.ucar.edu/stable/user/mlevy/proxy/8787/status</a></li>\n",
        "</ul>\n",
        "</td>\n",
@@ -120,7 +120,7 @@
        "</table>"
       ],
       "text/plain": [
-       "<Client: 'tcp://10.12.206.48:42526' processes=0 threads=0, memory=0 B>"
+       "<Client: 'tcp://10.12.206.46:44096' processes=0 threads=0, memory=0 B>"
       ]
      },
      "execution_count": 2,
@@ -367,8 +367,8 @@
       "Ocean volume in cesm2_SSP3-7.0: 1.324393977968355e+21 liter\n",
       "Ocean volume in cesm2_SSP5-8.5: 1.324393977968355e+21 liter\n",
       "Estimated ocean volume: 1.3400319094588905e+21 liter\n",
-      "CPU times: user 711 ms, sys: 457 ms, total: 1.17 s\n",
-      "Wall time: 1.66 s\n"
+      "CPU times: user 756 ms, sys: 925 ms, total: 1.68 s\n",
+      "Wall time: 1.82 s\n"
      ]
     }
    ],
@@ -481,10 +481,13 @@
     "\n",
     "    # compute\n",
     "    with xr.set_options(keep_attrs=True):\n",
-    "        return xr.merge((\n",
+    "        ds_out = xr.merge((\n",
     "            ds[other_vars],\n",
     "            (ds[time_vars] * weights).groupby('time.year').sum(dim='time'),\n",
-    "        )).rename({'year': 'time'})\n",
+    "        ))\n",
+    "        # Replace year dimension with midpoint of each year\n",
+    "        ds_out['year'] = ds['time'].groupby('time.year').mean()\n",
+    "        return ds_out.rename({'year': 'time'})\n",
     "\n",
     "def _compute_global_average_and_resample(dataset, exp, variable, integral_units):\n",
     "    unit_key = 'volume' if any(zdim in dataset[variable].dims for zdim in ['z_t_100m', 'z_t_150m', 'z_t']) else 'area'\n",
@@ -563,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -933,56 +936,8 @@
       "assuming cache is correct\n",
       "reading cached file: /glade/p/cgd/oce/projects/cesm2-marbl/xpersist_cache/no_marginal_seas/cesm2_PI_DENITRIF.nc\n",
       "\n",
-      "2021-05-25 17:21:49.339838: Getting data via intake-esm\n",
-      "Reading DENITRIF from cesm2_hist\n",
-      "----\n",
-      "\n",
-      "\n",
-      "--> The keys in the returned dictionary of datasets are constructed as follows:\n",
-      "\t'component.experiment.stream'\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "    <div>\n",
-       "        <style>\n",
-       "            /* Turns off some styling */\n",
-       "            progress {\n",
-       "                /* gets rid of default border in Firefox and Opera. */\n",
-       "                border: none;\n",
-       "                /* Needs to be in here for Safari polyfill so background images work as expected. */\n",
-       "                background-size: auto;\n",
-       "            }\n",
-       "            .progress-bar-interrupted, .progress-bar-interrupted::-webkit-progress-bar {\n",
-       "                background: #F44336;\n",
-       "            }\n",
-       "        </style>\n",
-       "      <progress value='1' class='' max='1' style='width:300px; height:20px; vertical-align: middle;'></progress>\n",
-       "      100.00% [1/1 00:00<00:00]\n",
-       "    </div>\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Done reading DENITRIF from cesm2_hist in 13.7s\n",
-      "\n",
-      "2021-05-25 17:22:03.025551: Calling esmlab.weighted_sum\n",
-      "2021-05-25 17:22:03.332744: Calling esmlab.resample\n",
-      "   ... computing for cesm2_hist\n",
-      "2021-05-25 17:22:06.919938: Determining units and returning\n",
-      "writing cache file: /glade/p/cgd/oce/projects/cesm2-marbl/xpersist_cache/no_marginal_seas/cesm2_hist_DENITRIF.nc\n",
+      "assuming cache is correct\n",
+      "reading cached file: /glade/p/cgd/oce/projects/cesm2-marbl/xpersist_cache/no_marginal_seas/cesm2_hist_DENITRIF.nc\n",
       "\n",
       "assuming cache is correct\n",
       "reading cached file: /glade/p/cgd/oce/projects/cesm2-marbl/xpersist_cache/no_marginal_seas/cesm2_SSP1-2.6_DENITRIF.nc\n",
@@ -1193,8 +1148,8 @@
       "assuming cache is correct\n",
       "reading cached file: /glade/p/cgd/oce/projects/cesm2-marbl/xpersist_cache/no_marginal_seas/cesm2_SSP5-8.5_O2_under_thres.nc\n",
       "\n",
-      "CPU times: user 1min, sys: 2.99 s, total: 1min 3s\n",
-      "Wall time: 5min 20s\n"
+      "CPU times: user 1.29 s, sys: 72.2 ms, total: 1.36 s\n",
+      "Wall time: 1.41 s\n"
      ]
     }
    ],


### PR DESCRIPTION
In Make Timeseries.ipynb, I had replaced esmlab.resample() with a new function
because esmlab.resample() doesn't work with the current stack. However, the new
function was setting the time dimension equal to the year being averaged,
rather than the midpoint of the points... e.g. 1990 rather than 1990-07-01.
This was resulting in the Global Flux Table using the wrong slice of years.

This commit includes:

1. updating the time dimension in the dataset returned by resample_ann()
2. updating ann_avg_utils:_get_time_and_ensemble_mean() to print a warning if
   the number of years being averaged doesn't match what is expected (which
   will catch averaging 1991-2014 instead of 1990-2014, but won't catch
   averaging 1989-1999 instead of 1990-2000)
3. regenerating the Global Flux Table using datasets with the correct time
   dimension